### PR TITLE
FreshmintClaimSale: change access on paymentReceiver, borrowPaymentReceiver to public

### DIFF
--- a/cadence/freshmint-claim-sale/FreshmintClaimSale.cdc
+++ b/cadence/freshmint-claim-sale/FreshmintClaimSale.cdc
@@ -180,7 +180,7 @@ pub contract FreshmintClaimSale {
 
         /// A capability to the receiver that will receive payments from this sale.
         ///
-        access(self) let paymentReceiver: Capability<&{FungibleToken.Receiver}>
+        pub let paymentReceiver: Capability<&{FungibleToken.Receiver}>
 
         /// An optional allowlist used to gate access to this sale.
         ///
@@ -245,7 +245,7 @@ pub contract FreshmintClaimSale {
         /// borrowPaymentReceiver returns a reference to the
         /// payment receiver for this sale.
         ///
-        access(self) fun borrowPaymentReceiver(): &{FungibleToken.Receiver} {
+        pub fun borrowPaymentReceiver(): &{FungibleToken.Receiver} {
             return self.paymentReceiver.borrow() 
                 ?? panic("failed to borrow payment receiver capability")
         }

--- a/cadence/freshmint-claim-sale/FreshmintClaimSale.cdc
+++ b/cadence/freshmint-claim-sale/FreshmintClaimSale.cdc
@@ -154,6 +154,7 @@ pub contract FreshmintClaimSale {
 
         pub fun claim(payment: @FungibleToken.Vault, address: Address)
 
+        pub fun borrowPaymentReceiver(): &{FungibleToken.Receiver}
         pub fun borrowCollection(): &{NonFungibleToken.CollectionPublic, MetadataViews.ResolverCollection}
     }
 


### PR DESCRIPTION
This PR updates the `paymentReceiver` field and `borrowPaymentReceiver` function to be publicly accessible so that buyers can inspect where funds are being deposited.

There is no reason for the receiver to be private. This change is in line with how the NFT storefront works: https://github.com/onflow/nft-storefront/blob/main/contracts/NFTStorefrontV2.cdc#L108-L115
