### PR TITLE
Mutable collection metadata

### DIFF
--- a/cadence/nfts/blind-edition-nft/BlindEditionNFT.template.cdc
+++ b/cadence/nfts/blind-edition-nft/BlindEditionNFT.template.cdc
@@ -33,6 +33,8 @@ pub contract {{ contractName }}: NonFungibleToken {
 
     {{> royaltiesFields contractName=contractName }}
 
+    {{> collectionMetadataFields }}
+
     pub struct Metadata {
     
         {{#each fields}}
@@ -396,6 +398,8 @@ pub contract {{ contractName }}: NonFungibleToken {
         }
 
         {{> royaltiesAdmin contractName=contractName }}
+
+        {{> collectionMetadataAdmin contractName=contractName }}
     }
 
     /// Return a public path that is scoped to this contract.
@@ -445,6 +449,7 @@ pub contract {{ contractName }}: NonFungibleToken {
         self.placeholderImage = placeholderImage
 
         {{> royaltiesInit }}
+        {{> collectionMetadataInit }}
 
         self.totalSupply = 0
         self.totalEditions = 0

--- a/cadence/nfts/blind-nft/BlindNFT.template.cdc
+++ b/cadence/nfts/blind-nft/BlindNFT.template.cdc
@@ -29,6 +29,8 @@ pub contract {{ contractName }}: NonFungibleToken {
 
     {{> royaltiesFields contractName=contractName }}
 
+    {{> collectionMetadataFields }}
+
     pub struct Metadata {
 
         /// A salt that is published when the metadata is revealed.
@@ -365,6 +367,8 @@ pub contract {{ contractName }}: NonFungibleToken {
         }
 
         {{> royaltiesAdmin contractName=contractName }}
+
+        {{> collectionMetadataAdmin contractName=contractName }}
     }
 
     /// Return a public path that is scoped to this contract.
@@ -414,6 +418,7 @@ pub contract {{ contractName }}: NonFungibleToken {
         self.placeholderImage = placeholderImage
 
         {{> royaltiesInit }}
+        {{> collectionMetadataInit }}
 
         self.totalSupply = 0
 

--- a/cadence/nfts/common/partials/collection-metadata-admin.partial.cdc
+++ b/cadence/nfts/common/partials/collection-metadata-admin.partial.cdc
@@ -1,0 +1,5 @@
+/// Set the collection metadata for this contract.
+///
+pub fun setCollectionMetadata(_ collectionMetadata: MetadataViews.NFTCollectionDisplay) {
+    {{ contractName }}.collectionMetadata = collectionMetadata
+}

--- a/cadence/nfts/common/partials/collection-metadata-fields.partial.cdc
+++ b/cadence/nfts/common/partials/collection-metadata-fields.partial.cdc
@@ -1,0 +1,3 @@
+/// The collection-level metadata for all NFTs minted by this contract.
+///
+access(contract) var collectionMetadata: MetadataViews.NFTCollectionDisplay?

--- a/cadence/nfts/common/partials/collection-metadata-fields.partial.cdc
+++ b/cadence/nfts/common/partials/collection-metadata-fields.partial.cdc
@@ -1,3 +1,3 @@
 /// The collection-level metadata for all NFTs minted by this contract.
 ///
-access(contract) var collectionMetadata: MetadataViews.NFTCollectionDisplay?
+pub var collectionMetadata: MetadataViews.NFTCollectionDisplay?

--- a/cadence/nfts/common/partials/collection-metadata-init.partial.cdc
+++ b/cadence/nfts/common/partials/collection-metadata-init.partial.cdc
@@ -1,0 +1,1 @@
+self.collectionMetadata = nil

--- a/cadence/nfts/common/scripts/get_collection_metadata.template.cdc
+++ b/cadence/nfts/common/scripts/get_collection_metadata.template.cdc
@@ -1,0 +1,7 @@
+import {{ contractName }} from {{{ contractAddress }}}
+
+import MetadataViews from {{{ imports.MetadataViews }}}
+
+pub fun main(): MetadataViews.NFTCollectionDisplay? {
+    return {{ contractName }}.collectionMetadata
+}

--- a/cadence/nfts/common/transactions/set_collection_metadata.template.cdc
+++ b/cadence/nfts/common/transactions/set_collection_metadata.template.cdc
@@ -2,14 +2,30 @@ import {{ contractName }} from {{{ contractAddress }}}
 
 import MetadataViews from {{{ imports.MetadataViews }}}
 
+pub fun getFileView(maybeIPFSCID: String?, maybeIPFSPath: String?, maybeURL: String?): AnyStruct{MetadataViews.File} {
+    if let cid = maybeIPFSCID {
+        return MetadataViews.IPFSFile(cid: cid, path: maybeIPFSPath)
+    }
+
+    if let url = maybeURL {
+        return MetadataViews.HTTPFile(url)
+    }
+
+    panic("must specify either an IPFS CID or URL for each image")
+}
+
 transaction(
     name: String,
     description: String,
     externalURL: String,
-    squareImage: String,
-    squareImageType: String,
-    bannerImage: String,
-    bannerImageType: String,
+    squareImageIPFSCID: String?,
+    squareImageIPFSPath: String?,
+    squareImageURL: String?,
+    squareImageMediaType: String,
+    bannerImageIPFSCID: String?,
+    bannerImageIPFSPath: String?,
+    bannerImageURL: String?,
+    bannerImageMediaType: String,
     socials: {String: String}
 ) {
 
@@ -32,12 +48,20 @@ transaction(
             description: description,
             externalURL: MetadataViews.ExternalURL(externalURL),
             squareImage: MetadataViews.Media(
-                file: MetadataViews.IPFSFile(cid: squareImage, path: nil),
-                mediaType: squareImageType
+                file: getFileView(
+                    maybeIPFSCID: squareImageIPFSCID,
+                    maybeIPFSPath: squareImageIPFSPath,
+                    maybeURL: squareImageURL
+                ),
+                mediaType: squareImageMediaType
             ),
             bannerImage: MetadataViews.Media(
-                file: MetadataViews.IPFSFile(cid: bannerImage, path: nil),
-                mediaType: bannerImageType
+                file: getFileView(
+                    maybeIPFSCID: bannerImageIPFSCID,
+                    maybeIPFSPath: bannerImageIPFSPath,
+                    maybeURL: bannerImageURL
+                ),
+                mediaType: bannerImageMediaType
             ),
             socials: socialURLs
         )

--- a/cadence/nfts/common/transactions/set_collection_metadata.template.cdc
+++ b/cadence/nfts/common/transactions/set_collection_metadata.template.cdc
@@ -1,0 +1,47 @@
+import {{ contractName }} from {{{ contractAddress }}}
+
+import MetadataViews from {{{ imports.MetadataViews }}}
+
+transaction(
+    name: String,
+    description: String,
+    externalURL: String,
+    squareImage: String,
+    squareImageType: String,
+    bannerImage: String,
+    bannerImageType: String,
+    socials: {String: String}
+) {
+
+    let admin: &{{ contractName }}.Admin
+
+    prepare(signer: AuthAccount) {
+        self.admin = signer.borrow<&{{ contractName }}.Admin>(from: {{ contractName }}.AdminStoragePath)
+            ?? panic("Could not borrow a reference to the NFT admin")
+    }
+
+    execute {
+        let socialURLs: {String: MetadataViews.ExternalURL} = {}
+
+        for key in socials.keys {
+            socialURLs[key] = MetadataViews.ExternalURL(socials[key]!)
+        }
+
+        let collectionMetadata = MetadataViews.NFTCollectionDisplay(
+            name: name,
+            description: description,
+            externalURL: MetadataViews.ExternalURL(externalURL),
+            squareImage: MetadataViews.Media(
+                file: MetadataViews.IPFSFile(cid: squareImage, path: nil),
+                mediaType: squareImageType
+            ),
+            bannerImage: MetadataViews.Media(
+                file: MetadataViews.IPFSFile(cid: bannerImage, path: nil),
+                mediaType: bannerImageType
+            ),
+            socials: socialURLs
+        )
+
+        self.admin.setCollectionMetadata(collectionMetadata)
+    }
+}

--- a/cadence/nfts/edition-nft/EditionNFT.template.cdc
+++ b/cadence/nfts/edition-nft/EditionNFT.template.cdc
@@ -28,6 +28,8 @@ pub contract {{ contractName }}: NonFungibleToken {
 
     {{> royaltiesFields contractName=contractName }}
 
+    {{> collectionMetadataFields }}
+
     pub struct Metadata {
     
         {{#each fields}}
@@ -329,6 +331,8 @@ pub contract {{ contractName }}: NonFungibleToken {
         }
 
         {{> royaltiesAdmin contractName=contractName }}
+
+        {{> collectionMetadataAdmin contractName=contractName }}
     }
 
     /// Return a public path that is scoped to this contract.
@@ -376,6 +380,7 @@ pub contract {{ contractName }}: NonFungibleToken {
         self.AdminStoragePath = {{ contractName }}.getStoragePath(suffix: "Admin")
 
         {{> royaltiesInit }}
+        {{> collectionMetadataInit }}
 
         self.totalSupply = 0
         self.totalEditions = 0

--- a/cadence/nfts/metadata-views/MetadataViews.ExternalURL.partial.cdc
+++ b/cadence/nfts/metadata-views/MetadataViews.ExternalURL.partial.cdc
@@ -1,6 +1,6 @@
 pub fun resolveExternalURL(): MetadataViews.ExternalURL {
     {{#if view.options.includesCollectionUrl }}
-    let collectionURL = {{ contractName }}.collectionDisplay!.externalURL.url
+    let collectionURL = {{ contractName }}.collectionMetadata!.externalURL.url
     {{/if}}
     {{#if view.options.includesNftOwner }}
     let nftOwner = self.owner!.address.toString()

--- a/cadence/nfts/metadata-views/MetadataViews.NFTCollectionDisplay.partial.cdc
+++ b/cadence/nfts/metadata-views/MetadataViews.NFTCollectionDisplay.partial.cdc
@@ -1,4 +1,5 @@
 pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay {
+    {{#if view.options }}
     let media = MetadataViews.Media(
         {{#if view.options.media.ipfs }}
         file: MetadataViews.IPFSFile(
@@ -19,4 +20,7 @@ pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay {
         bannerImage: media,
         socials: {}
     )
+    {{ else }}
+    return {{ contractName }}.collectionMetadata
+    {{/if}}
 }

--- a/cadence/nfts/metadata-views/MetadataViews.NFTCollectionDisplay.partial.cdc
+++ b/cadence/nfts/metadata-views/MetadataViews.NFTCollectionDisplay.partial.cdc
@@ -1,4 +1,4 @@
-pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay {
+pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay? {
     {{#if view.options }}
     let media = MetadataViews.Media(
         {{#if view.options.media.ipfs }}

--- a/cadence/nfts/standard-nft/StandardNFT.template.cdc
+++ b/cadence/nfts/standard-nft/StandardNFT.template.cdc
@@ -23,6 +23,8 @@ pub contract {{ contractName }}: NonFungibleToken {
 
     {{> royaltiesFields contractName=contractName }}
 
+    {{> collectionMetadataFields }}
+
     pub struct Metadata {
 
         {{#each fields}}
@@ -209,6 +211,8 @@ pub contract {{ contractName }}: NonFungibleToken {
         }
 
         {{> royaltiesAdmin contractName=contractName }}
+
+        {{> collectionMetadataAdmin contractName=contractName }}
     }
 
     /// Return a public path that is scoped to this contract.
@@ -256,6 +260,7 @@ pub contract {{ contractName }}: NonFungibleToken {
         self.AdminStoragePath = {{ contractName }}.getStoragePath(suffix: "Admin")
 
         {{> royaltiesInit }}
+        {{> collectionMetadataInit }}
 
         self.totalSupply = 0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8296,7 +8296,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -8305,7 +8305,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -12729,6 +12728,7 @@
         "handlebars": "^4.7.7",
         "inquirer": "^8.2.2",
         "js-yaml": "^4.1.0",
+        "mime-types": "^2.1.35",
         "nft.storage": "^3.3.0",
         "node-fetch": "^2.6.7",
         "ora": "^5.4.1",
@@ -16606,6 +16606,7 @@
         "handlebars": "^4.7.7",
         "inquirer": "^8.2.2",
         "js-yaml": "^4.1.0",
+        "mime-types": "^2.1.35",
         "nft.storage": "^3.3.0",
         "node-fetch": "^2.6.7",
         "ora": "^5.4.1",
@@ -19174,14 +19175,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }

--- a/packages/core/cadence/index.ts
+++ b/packages/core/cadence/index.ts
@@ -1,0 +1,1 @@
+export * from './values';

--- a/packages/core/cadence/values.ts
+++ b/packages/core/cadence/values.ts
@@ -401,3 +401,13 @@ export class Path {
     return `/${this.domain}/${this.identifier}`;
   }
 }
+
+// objectToDictionaryEntries converts a JavaScript object to key-value pairs that
+// can be used as input to an FCL argument with type t.Dictionary.
+//
+// For example, see this test case in FCL-JS:
+// https://github.com/onflow/fcl-js/blob/1790eec53fc83be411c7dffd9c97f949ef506e07/packages/types/src/types.test.js#L84-L91
+//
+export function objectToDictionaryEntries(obj: { [key: string]: any }): { key: string; value: any }[] {
+  return Object.entries(obj).map(([key, value]) => ({ key, value }));
+}

--- a/packages/core/contracts/BlindEditionNFTContract.test.ts
+++ b/packages/core/contracts/BlindEditionNFTContract.test.ts
@@ -7,9 +7,10 @@ import {
   contractPublicKey,
   ownerAuthorizer,
   getTestSchema,
-  royaltiesTests,
   setupEmulator,
   teardownEmulator,
+  royaltiesTests,
+  collectionMetadataTests,
 } from '../testHelpers';
 
 describe('BlindEditionNFTContract', () => {
@@ -114,4 +115,5 @@ describe('BlindEditionNFTContract', () => {
   });
 
   royaltiesTests(client, contract);
+  collectionMetadataTests(client, contract);
 });

--- a/packages/core/contracts/BlindEditionNFTContract.ts
+++ b/packages/core/contracts/BlindEditionNFTContract.ts
@@ -3,7 +3,7 @@ import * as fcl from '@onflow/fcl';
 // @ts-ignore
 import * as t from '@onflow/types';
 
-import NFTContract from './NFTContract';
+import { NFTContract } from './NFTContract';
 import { MetadataMap } from '../metadata';
 import { BlindEditionNFTGenerator } from '../generators/BlindEditionNFTGenerator';
 import { hashValuesWithSalt } from '../hash';

--- a/packages/core/contracts/BlindNFTContract.test.ts
+++ b/packages/core/contracts/BlindNFTContract.test.ts
@@ -8,9 +8,10 @@ import {
   ownerAuthorizer,
   getTestSchema,
   getTestNFTs,
-  royaltiesTests,
   setupEmulator,
   teardownEmulator,
+  royaltiesTests,
+  collectionMetadataTests,
 } from '../testHelpers';
 
 describe('BlindNFTContract', () => {
@@ -122,4 +123,5 @@ describe('BlindNFTContract', () => {
   });
 
   royaltiesTests(client, contract);
+  collectionMetadataTests(client, contract);
 });

--- a/packages/core/contracts/BlindNFTContract.ts
+++ b/packages/core/contracts/BlindNFTContract.ts
@@ -3,7 +3,7 @@ import * as fcl from '@onflow/fcl';
 // @ts-ignore
 import * as t from '@onflow/types';
 
-import NFTContract from './NFTContract';
+import { NFTContract } from './NFTContract';
 import { MetadataMap, hashMetadataWithSalt } from '../metadata';
 import { BlindNFTGenerator } from '../generators/BlindNFTGenerator';
 import { FreshmintConfig, ContractImports } from '../config';

--- a/packages/core/contracts/ClaimSaleContract.ts
+++ b/packages/core/contracts/ClaimSaleContract.ts
@@ -6,7 +6,7 @@ import * as t from '@onflow/types';
 
 import { ClaimSaleGenerator } from '../generators/ClaimSaleGenerator';
 
-import NFTContract from './NFTContract';
+import { NFTContract } from './NFTContract';
 import { FreshmintConfig, ContractImports } from '../config';
 import { Transaction, TransactionAuthorizer, TransactionResult } from '../transactions';
 import { Path } from '../cadence/values';

--- a/packages/core/contracts/EditionNFTContract.test.ts
+++ b/packages/core/contracts/EditionNFTContract.test.ts
@@ -7,9 +7,10 @@ import {
   contractPublicKey,
   ownerAuthorizer,
   getTestSchema,
-  royaltiesTests,
   setupEmulator,
   teardownEmulator,
+  royaltiesTests,
+  collectionMetadataTests,
 } from '../testHelpers';
 
 describe('EditionNFTContract', () => {
@@ -147,4 +148,5 @@ describe('EditionNFTContract', () => {
   });
 
   royaltiesTests(client, contract);
+  collectionMetadataTests(client, contract);
 });

--- a/packages/core/contracts/EditionNFTContract.ts
+++ b/packages/core/contracts/EditionNFTContract.ts
@@ -3,7 +3,7 @@ import * as fcl from '@onflow/fcl';
 // @ts-ignore
 import * as t from '@onflow/types';
 
-import NFTContract from './NFTContract';
+import { NFTContract } from './NFTContract';
 import { MetadataMap } from '../metadata';
 import { EditionNFTGenerator } from '../generators/EditionNFTGenerator';
 import { FreshmintConfig, ContractImports } from '../config';

--- a/packages/core/contracts/NFTContract.ts
+++ b/packages/core/contracts/NFTContract.ts
@@ -21,7 +21,7 @@ export interface Royalty {
 export interface CollectionMetadata {
   name: string;
   description: string;
-  externalUrl: string;
+  url: string;
   squareImage: MediaInput;
   bannerImage: MediaInput;
   socials: { [name: string]: string };
@@ -165,7 +165,7 @@ export abstract class NFTContract {
         args: [
           fcl.arg(collectionMetadata.name, t.String),
           fcl.arg(collectionMetadata.description, t.String),
-          fcl.arg(collectionMetadata.externalUrl, t.String),
+          fcl.arg(collectionMetadata.url, t.String),
           fcl.arg(getIPFSCID(collectionMetadata.squareImage), t.Optional(t.String)),
           fcl.arg(getIPFSPath(collectionMetadata.squareImage), t.Optional(t.String)),
           fcl.arg(getHTTPURL(collectionMetadata.squareImage), t.Optional(t.String)),
@@ -228,7 +228,7 @@ function prepareRoyalties(royalties: Royalty[]): {
   return { royaltyAddresses, royaltyReceiverPaths, royaltyCuts, royaltyDescriptions };
 }
 
-function getIPFSCID(mediaInput: MediaInput): string | null {
+export function getIPFSCID(mediaInput: MediaInput): string | null {
   if (!isIPFSMediaInput(mediaInput)) {
     return null;
   }
@@ -236,7 +236,7 @@ function getIPFSCID(mediaInput: MediaInput): string | null {
   return typeof mediaInput.ipfs === 'string' ? mediaInput.ipfs : mediaInput.ipfs.cid;
 }
 
-function getIPFSPath(mediaInput: MediaInput): string | null {
+export function getIPFSPath(mediaInput: MediaInput): string | null {
   if (!isIPFSMediaInput(mediaInput)) {
     return null;
   }
@@ -244,7 +244,7 @@ function getIPFSPath(mediaInput: MediaInput): string | null {
   return typeof mediaInput.ipfs === 'string' ? null : mediaInput.ipfs.path || null;
 }
 
-function getHTTPURL(mediaInput: MediaInput): string | null {
+export function getHTTPURL(mediaInput: MediaInput): string | null {
   if (!isHTTPMediaInput(mediaInput)) {
     return null;
   }
@@ -260,7 +260,7 @@ function parseCollectionMetadataResult(result: any | null): CollectionMetadata |
   return {
     name: result.name,
     description: result.description,
-    externalUrl: result.externalURL.url,
+    url: result.externalURL.url,
     squareImage: parseMedia(result.squareImage),
     bannerImage: parseMedia(result.bannerImage),
     socials: parseSocials(result.socials),

--- a/packages/core/contracts/StandardNFTContract.test.ts
+++ b/packages/core/contracts/StandardNFTContract.test.ts
@@ -9,9 +9,10 @@ import {
   ownerAuthorizer,
   getTestSchema,
   getTestNFTs,
-  royaltiesTests,
   setupEmulator,
   teardownEmulator,
+  royaltiesTests,
+  collectionMetadataTests,
 } from '../testHelpers';
 
 describe('StandardNFTContract', () => {
@@ -99,4 +100,5 @@ describe('StandardNFTContract', () => {
   });
 
   royaltiesTests(client, contract);
+  collectionMetadataTests(client, contract);
 });

--- a/packages/core/contracts/StandardNFTContract.ts
+++ b/packages/core/contracts/StandardNFTContract.ts
@@ -5,7 +5,7 @@ import * as t from '@onflow/types';
 
 import { PublicKey, SignatureAlgorithm, HashAlgorithm } from '../crypto';
 
-import NFTContract from './NFTContract';
+import { NFTContract } from './NFTContract';
 import { MetadataMap } from '../metadata';
 import { StandardNFTGenerator } from '../generators/StandardNFTGenerator';
 import { FreshmintConfig, ContractImports } from '../config';

--- a/packages/core/contracts/__snapshots__/BlindEditionNFTContract.test.ts.snap
+++ b/packages/core/contracts/__snapshots__/BlindEditionNFTContract.test.ts.snap
@@ -47,7 +47,7 @@ pub contract BlindEditionNFT_Test: NonFungibleToken {
 
     /// The collection-level metadata for all NFTs minted by this contract.
     ///
-    access(contract) var collectionMetadata: MetadataViews.NFTCollectionDisplay?
+    pub var collectionMetadata: MetadataViews.NFTCollectionDisplay?
 
     pub struct Metadata {
     
@@ -250,7 +250,7 @@ pub contract BlindEditionNFT_Test: NonFungibleToken {
             return MetadataViews.ExternalURL(\\"http://foo.com/\\".concat(self.id.toString()))
         }
         
-        pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay {
+        pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay? {
             let media = MetadataViews.Media(
                 file: MetadataViews.IPFSFile(
                     cid: \\"bafkreicrfbblmaduqg2kmeqbymdifawex7rxqq2743mitmeia4zdybmmre\\", 

--- a/packages/core/contracts/__snapshots__/BlindEditionNFTContract.test.ts.snap
+++ b/packages/core/contracts/__snapshots__/BlindEditionNFTContract.test.ts.snap
@@ -45,6 +45,10 @@ pub contract BlindEditionNFT_Test: NonFungibleToken {
         return BlindEditionNFT_Test.royalties
     }
 
+    /// The collection-level metadata for all NFTs minted by this contract.
+    ///
+    access(contract) var collectionMetadata: MetadataViews.NFTCollectionDisplay?
+
     pub struct Metadata {
     
         pub let name: String
@@ -479,6 +483,12 @@ pub contract BlindEditionNFT_Test: NonFungibleToken {
         pub fun setRoyalties(_ royalties: [MetadataViews.Royalty]) {
             BlindEditionNFT_Test.royalties = royalties
         }
+
+        /// Set the collection metadata for this contract.
+        ///
+        pub fun setCollectionMetadata(_ collectionMetadata: MetadataViews.NFTCollectionDisplay) {
+            BlindEditionNFT_Test.collectionMetadata = collectionMetadata
+        }
     }
 
     /// Return a public path that is scoped to this contract.
@@ -528,6 +538,7 @@ pub contract BlindEditionNFT_Test: NonFungibleToken {
         self.placeholderImage = placeholderImage
 
         self.royalties = []
+        self.collectionMetadata = nil
 
         self.totalSupply = 0
         self.totalEditions = 0

--- a/packages/core/contracts/__snapshots__/BlindNFTContract.test.ts.snap
+++ b/packages/core/contracts/__snapshots__/BlindNFTContract.test.ts.snap
@@ -41,6 +41,10 @@ pub contract BlindNFT_Test: NonFungibleToken {
         return BlindNFT_Test.royalties
     }
 
+    /// The collection-level metadata for all NFTs minted by this contract.
+    ///
+    access(contract) var collectionMetadata: MetadataViews.NFTCollectionDisplay?
+
     pub struct Metadata {
 
         /// A salt that is published when the metadata is revealed.
@@ -455,6 +459,12 @@ pub contract BlindNFT_Test: NonFungibleToken {
         pub fun setRoyalties(_ royalties: [MetadataViews.Royalty]) {
             BlindNFT_Test.royalties = royalties
         }
+
+        /// Set the collection metadata for this contract.
+        ///
+        pub fun setCollectionMetadata(_ collectionMetadata: MetadataViews.NFTCollectionDisplay) {
+            BlindNFT_Test.collectionMetadata = collectionMetadata
+        }
     }
 
     /// Return a public path that is scoped to this contract.
@@ -504,6 +514,7 @@ pub contract BlindNFT_Test: NonFungibleToken {
         self.placeholderImage = placeholderImage
 
         self.royalties = []
+        self.collectionMetadata = nil
 
         self.totalSupply = 0
 

--- a/packages/core/contracts/__snapshots__/BlindNFTContract.test.ts.snap
+++ b/packages/core/contracts/__snapshots__/BlindNFTContract.test.ts.snap
@@ -43,7 +43,7 @@ pub contract BlindNFT_Test: NonFungibleToken {
 
     /// The collection-level metadata for all NFTs minted by this contract.
     ///
-    access(contract) var collectionMetadata: MetadataViews.NFTCollectionDisplay?
+    pub var collectionMetadata: MetadataViews.NFTCollectionDisplay?
 
     pub struct Metadata {
 
@@ -244,7 +244,7 @@ pub contract BlindNFT_Test: NonFungibleToken {
             return MetadataViews.ExternalURL(\\"http://foo.com/\\".concat(self.id.toString()))
         }
         
-        pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay {
+        pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay? {
             let media = MetadataViews.Media(
                 file: MetadataViews.IPFSFile(
                     cid: \\"bafkreicrfbblmaduqg2kmeqbymdifawex7rxqq2743mitmeia4zdybmmre\\", 

--- a/packages/core/contracts/__snapshots__/EditionNFTContract.test.ts.snap
+++ b/packages/core/contracts/__snapshots__/EditionNFTContract.test.ts.snap
@@ -42,7 +42,7 @@ pub contract EditionNFT_Test: NonFungibleToken {
 
     /// The collection-level metadata for all NFTs minted by this contract.
     ///
-    access(contract) var collectionMetadata: MetadataViews.NFTCollectionDisplay?
+    pub var collectionMetadata: MetadataViews.NFTCollectionDisplay?
 
     pub struct Metadata {
     
@@ -193,7 +193,7 @@ pub contract EditionNFT_Test: NonFungibleToken {
             return MetadataViews.ExternalURL(\\"http://foo.com/\\".concat(self.id.toString()))
         }
         
-        pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay {
+        pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay? {
             let media = MetadataViews.Media(
                 file: MetadataViews.IPFSFile(
                     cid: \\"bafkreicrfbblmaduqg2kmeqbymdifawex7rxqq2743mitmeia4zdybmmre\\", 

--- a/packages/core/contracts/__snapshots__/EditionNFTContract.test.ts.snap
+++ b/packages/core/contracts/__snapshots__/EditionNFTContract.test.ts.snap
@@ -40,6 +40,10 @@ pub contract EditionNFT_Test: NonFungibleToken {
         return EditionNFT_Test.royalties
     }
 
+    /// The collection-level metadata for all NFTs minted by this contract.
+    ///
+    access(contract) var collectionMetadata: MetadataViews.NFTCollectionDisplay?
+
     pub struct Metadata {
     
         pub let name: String
@@ -416,6 +420,12 @@ pub contract EditionNFT_Test: NonFungibleToken {
         pub fun setRoyalties(_ royalties: [MetadataViews.Royalty]) {
             EditionNFT_Test.royalties = royalties
         }
+
+        /// Set the collection metadata for this contract.
+        ///
+        pub fun setCollectionMetadata(_ collectionMetadata: MetadataViews.NFTCollectionDisplay) {
+            EditionNFT_Test.collectionMetadata = collectionMetadata
+        }
     }
 
     /// Return a public path that is scoped to this contract.
@@ -463,6 +473,7 @@ pub contract EditionNFT_Test: NonFungibleToken {
         self.AdminStoragePath = EditionNFT_Test.getStoragePath(suffix: \\"Admin\\")
 
         self.royalties = []
+        self.collectionMetadata = nil
 
         self.totalSupply = 0
         self.totalEditions = 0

--- a/packages/core/contracts/__snapshots__/StandardNFTContract.test.ts.snap
+++ b/packages/core/contracts/__snapshots__/StandardNFTContract.test.ts.snap
@@ -37,7 +37,7 @@ pub contract StandardNFT_Test: NonFungibleToken {
 
     /// The collection-level metadata for all NFTs minted by this contract.
     ///
-    access(contract) var collectionMetadata: MetadataViews.NFTCollectionDisplay?
+    pub var collectionMetadata: MetadataViews.NFTCollectionDisplay?
 
     pub struct Metadata {
 
@@ -127,7 +127,7 @@ pub contract StandardNFT_Test: NonFungibleToken {
             return MetadataViews.ExternalURL(\\"http://foo.com/\\".concat(self.id.toString()))
         }
         
-        pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay {
+        pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay? {
             let media = MetadataViews.Media(
                 file: MetadataViews.IPFSFile(
                     cid: \\"bafkreicrfbblmaduqg2kmeqbymdifawex7rxqq2743mitmeia4zdybmmre\\", 

--- a/packages/core/contracts/__snapshots__/StandardNFTContract.test.ts.snap
+++ b/packages/core/contracts/__snapshots__/StandardNFTContract.test.ts.snap
@@ -35,6 +35,10 @@ pub contract StandardNFT_Test: NonFungibleToken {
         return StandardNFT_Test.royalties
     }
 
+    /// The collection-level metadata for all NFTs minted by this contract.
+    ///
+    access(contract) var collectionMetadata: MetadataViews.NFTCollectionDisplay?
+
     pub struct Metadata {
 
         pub let name: String
@@ -308,6 +312,12 @@ pub contract StandardNFT_Test: NonFungibleToken {
         pub fun setRoyalties(_ royalties: [MetadataViews.Royalty]) {
             StandardNFT_Test.royalties = royalties
         }
+
+        /// Set the collection metadata for this contract.
+        ///
+        pub fun setCollectionMetadata(_ collectionMetadata: MetadataViews.NFTCollectionDisplay) {
+            StandardNFT_Test.collectionMetadata = collectionMetadata
+        }
     }
 
     /// Return a public path that is scoped to this contract.
@@ -355,6 +365,7 @@ pub contract StandardNFT_Test: NonFungibleToken {
         self.AdminStoragePath = StandardNFT_Test.getStoragePath(suffix: \\"Admin\\")
 
         self.royalties = []
+        self.collectionMetadata = nil
 
         self.totalSupply = 0
 

--- a/packages/core/generators/CommonNFTGenerator.ts
+++ b/packages/core/generators/CommonNFTGenerator.ts
@@ -9,6 +9,11 @@ registerPartial('royaltiesFields', require('../../../cadence/nfts/common/partial
 registerPartial('royaltiesAdmin', require('../../../cadence/nfts/common/partials/royalties-admin.partial.cdc'));
 registerPartial('royaltiesInit', require('../../../cadence/nfts/common/partials/royalties-init.partial.cdc'));
 
+// Register the collection metadata partials
+registerPartial('collectionMetadataFields', require('../../../cadence/nfts/common/partials/collection-metadata-fields.partial.cdc'));
+registerPartial('collectionMetadataAdmin', require('../../../cadence/nfts/common/partials/collection-metadata-admin.partial.cdc'));
+registerPartial('collectionMetadataInit', require('../../../cadence/nfts/common/partials/collection-metadata-init.partial.cdc'));
+
 export class CommonNFTGenerator extends TemplateGenerator {
   static getNFT({
     imports,

--- a/packages/core/generators/CommonNFTGenerator.ts
+++ b/packages/core/generators/CommonNFTGenerator.ts
@@ -78,4 +78,20 @@ export class CommonNFTGenerator extends TemplateGenerator {
       contractAddress,
     });
   }
+
+  static setCollectionMetadata({
+    imports,
+    contractName,
+    contractAddress,
+  }: {
+    imports: ContractImports;
+    contractName: string;
+    contractAddress: string;
+  }): string {
+    return this.generate(require('../../../cadence/nfts/common/transactions/set_collection_metadata.template.cdc'), {
+      imports,
+      contractName,
+      contractAddress,
+    });
+  }
 }

--- a/packages/core/generators/CommonNFTGenerator.ts
+++ b/packages/core/generators/CommonNFTGenerator.ts
@@ -10,9 +10,18 @@ registerPartial('royaltiesAdmin', require('../../../cadence/nfts/common/partials
 registerPartial('royaltiesInit', require('../../../cadence/nfts/common/partials/royalties-init.partial.cdc'));
 
 // Register the collection metadata partials
-registerPartial('collectionMetadataFields', require('../../../cadence/nfts/common/partials/collection-metadata-fields.partial.cdc'));
-registerPartial('collectionMetadataAdmin', require('../../../cadence/nfts/common/partials/collection-metadata-admin.partial.cdc'));
-registerPartial('collectionMetadataInit', require('../../../cadence/nfts/common/partials/collection-metadata-init.partial.cdc'));
+registerPartial(
+  'collectionMetadataFields',
+  require('../../../cadence/nfts/common/partials/collection-metadata-fields.partial.cdc'),
+);
+registerPartial(
+  'collectionMetadataAdmin',
+  require('../../../cadence/nfts/common/partials/collection-metadata-admin.partial.cdc'),
+);
+registerPartial(
+  'collectionMetadataInit',
+  require('../../../cadence/nfts/common/partials/collection-metadata-init.partial.cdc'),
+);
 
 export class CommonNFTGenerator extends TemplateGenerator {
   static getNFT({

--- a/packages/core/generators/CommonNFTGenerator.ts
+++ b/packages/core/generators/CommonNFTGenerator.ts
@@ -103,4 +103,20 @@ export class CommonNFTGenerator extends TemplateGenerator {
       contractAddress,
     });
   }
+
+  static getCollectionMetadata({
+    imports,
+    contractName,
+    contractAddress,
+  }: {
+    imports: ContractImports;
+    contractName: string;
+    contractAddress: string;
+  }): string {
+    return this.generate(require('../../../cadence/nfts/common/scripts/get_collection_metadata.template.cdc'), {
+      imports,
+      contractName,
+      contractAddress,
+    });
+  }
 }

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -8,6 +8,7 @@ export { FreshmintClient } from './client';
 export { Transaction, TransactionAuthorizer } from './transactions';
 export type { TransactionResult, TransactionEvent } from './transactions';
 
+export { getIPFSCID, getIPFSPath, getHTTPURL } from './contracts/NFTContract';
 export type { Royalty, CollectionMetadata } from './contracts/NFTContract';
 
 export { StandardNFTContract } from './contracts/StandardNFTContract';

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -8,6 +8,8 @@ export { FreshmintClient } from './client';
 export { Transaction, TransactionAuthorizer } from './transactions';
 export type { TransactionResult, TransactionEvent } from './transactions';
 
+export type { Royalty, CollectionMetadata } from './contracts/NFTContract';
+
 export { StandardNFTContract } from './contracts/StandardNFTContract';
 export { BlindNFTContract } from './contracts/BlindNFTContract';
 export { EditionNFTContract } from './contracts/EditionNFTContract';

--- a/packages/core/metadata/__snapshots__/views.test.ts.snap
+++ b/packages/core/metadata/__snapshots__/views.test.ts.snap
@@ -9,7 +9,7 @@ exports[`ExternalURLView accepts a complete Cadence expression 1`] = `
 
 exports[`ExternalURLView accepts a raw template that uses all variables 1`] = `
 "pub fun resolveExternalURL(): MetadataViews.ExternalURL {
-    let collectionURL = Foo.collectionDisplay!.externalURL.url
+    let collectionURL = Foo.collectionMetadata!.externalURL.url
     let nftOwner = self.owner!.address.toString()
     let nftID = self.id.toString()
     return MetadataViews.ExternalURL(collectionURL.concat(\\"/nfts/\\").concat(nftOwner).concat(\\"/\\").concat(nftID))
@@ -26,7 +26,7 @@ exports[`ExternalURLView accepts a raw template that uses no variables 1`] = `
 
 exports[`ExternalURLView accepts a raw template that uses the \${collection.url} variable 1`] = `
 "pub fun resolveExternalURL(): MetadataViews.ExternalURL {
-    let collectionURL = Foo.collectionDisplay!.externalURL.url
+    let collectionURL = Foo.collectionMetadata!.externalURL.url
     return MetadataViews.ExternalURL(collectionURL.concat(\\"/nfts\\"))
 }
 "

--- a/packages/core/metadata/__snapshots__/views.test.ts.snap
+++ b/packages/core/metadata/__snapshots__/views.test.ts.snap
@@ -111,6 +111,13 @@ exports[`NFTCollectionDisplayView generates a Cadence snippet with an IPFS media
 "
 `;
 
+exports[`NFTCollectionDisplayView returns the collectionMetadata field when no options are passed 1`] = `
+"pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay {
+    return Foo.collectionMetadata
+}
+"
+`;
+
 exports[`SerialView generates a Cadence snippet 1`] = `
 "pub fun resolveSerial(_ metadata: Metadata): MetadataViews.Serial {
     return MetadataViews.Serial(metadata.serialNumber)

--- a/packages/core/metadata/__snapshots__/views.test.ts.snap
+++ b/packages/core/metadata/__snapshots__/views.test.ts.snap
@@ -49,7 +49,7 @@ exports[`ExternalURLView accepts a raw template that uses the \${nft.owner} vari
 `;
 
 exports[`NFTCollectionDisplayView generates a Cadence snippet with an HTTP media file 1`] = `
-"pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay {
+"pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay? {
     let media = MetadataViews.Media(
         file: MetadataViews.HTTPFile(url: \\"http://foo.com/nft.jpeg\\"),
         mediaType: \\"image/jpeg\\"
@@ -68,7 +68,7 @@ exports[`NFTCollectionDisplayView generates a Cadence snippet with an HTTP media
 `;
 
 exports[`NFTCollectionDisplayView generates a Cadence snippet with an IPFS media file with a path 1`] = `
-"pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay {
+"pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay? {
     let media = MetadataViews.Media(
         file: MetadataViews.IPFSFile(
             cid: \\"bafkreicrfbblmaduqg2kmeqbymdifawex7rxqq2743mitmeia4zdybmmre\\", 
@@ -90,7 +90,7 @@ exports[`NFTCollectionDisplayView generates a Cadence snippet with an IPFS media
 `;
 
 exports[`NFTCollectionDisplayView generates a Cadence snippet with an IPFS media file with no path 1`] = `
-"pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay {
+"pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay? {
     let media = MetadataViews.Media(
         file: MetadataViews.IPFSFile(
             cid: \\"bafkreicrfbblmaduqg2kmeqbymdifawex7rxqq2743mitmeia4zdybmmre\\", 
@@ -112,7 +112,7 @@ exports[`NFTCollectionDisplayView generates a Cadence snippet with an IPFS media
 `;
 
 exports[`NFTCollectionDisplayView returns the collectionMetadata field when no options are passed 1`] = `
-"pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay {
+"pub fun resolveNFTCollectionDisplay(): MetadataViews.NFTCollectionDisplay? {
     return Foo.collectionMetadata
 }
 "

--- a/packages/core/metadata/views.test.ts
+++ b/packages/core/metadata/views.test.ts
@@ -109,6 +109,11 @@ describe('NFTCollectionDisplayView', () => {
 
     expect(generateView(view)).toMatchSnapshot();
   });
+
+  it('returns the collectionMetadata field when no options are passed', () => {
+    const view = metadata.NFTCollectionDisplayView();
+    expect(generateView(view)).toMatchSnapshot();
+  });
 });
 
 describe('SerialView', () => {

--- a/packages/core/metadata/views.ts
+++ b/packages/core/metadata/views.ts
@@ -230,11 +230,11 @@ function isLegacyIPFSMediaInput(media: MediaInput): media is LegacyIPFSMediaInpu
   return (media as LegacyIPFSMediaInput).ipfsCid !== undefined;
 }
 
-function isIPFSMediaInput(media: MediaInput): media is IPFSMediaInput {
+export function isIPFSMediaInput(media: MediaInput): media is IPFSMediaInput {
   return (media as IPFSMediaInput).ipfs !== undefined;
 }
 
-function isHTTPMediaInput(media: MediaInput): media is HTTPMediaInput {
+export function isHTTPMediaInput(media: MediaInput): media is HTTPMediaInput {
   return (media as HTTPMediaInput).url !== undefined;
 }
 

--- a/packages/core/metadata/views.ts
+++ b/packages/core/metadata/views.ts
@@ -243,13 +243,19 @@ export const NFTCollectionDisplayView = defineView<{
   description: string;
   url: string;
   media: MediaInput;
-}>({
+} | void>({
   id: 'nft-collection-display',
   cadenceTypeString: 'Type<MetadataViews.NFTCollectionDisplay>()',
   cadenceResolverFunction: 'resolveNFTCollectionDisplay',
   cadenceTemplate: require('../../../cadence/nfts/metadata-views/MetadataViews.NFTCollectionDisplay.partial.cdc'),
   requiresMetadata: false,
   parseOptions: (options) => {
+    if (!options) {
+      // If no options are passed, the resolver will return
+      // the data defined in the `collectionMetadata` contract field.
+      return;
+    }
+    
     // Convert the legacy IPFS format to the new generic file format.
     //
     // TODO: deprecate the ipfsCid field.

--- a/packages/core/metadata/views.ts
+++ b/packages/core/metadata/views.ts
@@ -255,7 +255,7 @@ export const NFTCollectionDisplayView = defineView<{
       // the data defined in the `collectionMetadata` contract field.
       return;
     }
-    
+
     // Convert the legacy IPFS format to the new generic file format.
     //
     // TODO: deprecate the ipfsCid field.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,11 +32,16 @@
       "require": "./dist/metadata/index.js",
       "import": "./dist/metadata/index.mjs",
       "types": "./dist/metadata/index.d.ts"
+    },
+    "./cadence": {
+      "require": "./dist/cadence/index.js",
+      "import": "./dist/cadence/index.mjs",
+      "types": "./dist/cadence/index.d.ts"
     }
   },
   "scripts": {
     "test": "jest --runInBand --bail",
-    "build": "tsup index.ts crypto/index.ts metadata/index.ts --clean --loader \".cdc=text\" --dts --sourcemap --format esm,cjs --splitting",
+    "build": "tsup index.ts crypto/index.ts metadata/index.ts cadence/index.ts --clean --loader \".cdc=text\" --dts --sourcemap --format esm,cjs --splitting",
     "dev": "npm run build -- --watch",
     "lint": "eslint . --ext .ts"
   },

--- a/packages/core/testHelpers.ts
+++ b/packages/core/testHelpers.ts
@@ -9,7 +9,7 @@ import { FreshmintClient } from './client';
 import { TransactionAuthorizer } from './transactions';
 import { HashAlgorithm, InMemoryECPrivateKey, InMemoryECSigner, SignatureAlgorithm } from './crypto';
 import * as metadata from './metadata';
-import NFTContract from './contracts/NFTContract';
+import { NFTContract, CollectionMetadata } from './contracts/NFTContract';
 import { FreshmintMetadataViewsGenerator } from './generators/FreshmintMetadataViewsGenerator';
 import { ClaimSaleGenerator } from './generators/ClaimSaleGenerator';
 
@@ -225,5 +225,62 @@ export function royaltiesTests(client: FreshmintClient, contract: NFTContract) {
     const onChainRoyalties = await client.query(contract.getRoyalties());
 
     expect(onChainRoyalties).toEqual([]);
+  });
+}
+
+export function collectionMetadataTests(client: FreshmintClient, contract: NFTContract) {
+  it('collection metadata should be empty', async () => {
+    const collectionMetadata = await client.query(contract.getCollectionMetadata());
+    expect(collectionMetadata).toBe(null);
+  });
+
+  it('should be able to set collection metadata', async () => {
+    const collectionMetadataInput: CollectionMetadata = {
+      name: 'Foo NFT Collection',
+      description: 'This is the Foo NFT collection.',
+      externalUrl: 'https://foo.com',
+      squareImage: {
+        url: 'https://foo.com/square.png',
+        type: 'image/png',
+      },
+      bannerImage: {
+        url: 'https://foo.com/banner.png',
+        type: 'image/png',
+      },
+      socials: {
+        twitter: 'https://twitter.com/foo',
+      },
+    };
+
+    await client.send(contract.setCollectionMetadata(collectionMetadataInput));
+
+    const collectionMetadata = await client.query(contract.getCollectionMetadata());
+
+    expect(collectionMetadata).toEqual(collectionMetadataInput);
+  });
+
+  it('should be able to update collection metadata', async () => {
+    const collectionMetadataInput = {
+      name: 'Bar NFT Collection',
+      description: 'This is the Bar NFT collection.',
+      externalUrl: 'https://bar.com',
+      squareImage: {
+        url: 'https://bar.com/square.png',
+        type: 'image/png',
+      },
+      bannerImage: {
+        url: 'https://bar.com/banner.png',
+        type: 'image/png',
+      },
+      socials: {
+        twitter: 'https://twitter.com/bar',
+      },
+    };
+
+    await client.send(contract.setCollectionMetadata(collectionMetadataInput));
+
+    const collectionMetadata = await client.query(contract.getCollectionMetadata());
+
+    expect(collectionMetadata).toEqual(collectionMetadataInput);
   });
 }

--- a/packages/core/testHelpers.ts
+++ b/packages/core/testHelpers.ts
@@ -238,7 +238,7 @@ export function collectionMetadataTests(client: FreshmintClient, contract: NFTCo
     const collectionMetadataInput: CollectionMetadata = {
       name: 'Foo NFT Collection',
       description: 'This is the Foo NFT collection.',
-      externalUrl: 'https://foo.com',
+      url: 'https://foo.com',
       squareImage: {
         url: 'https://foo.com/square.png',
         type: 'image/png',
@@ -260,10 +260,10 @@ export function collectionMetadataTests(client: FreshmintClient, contract: NFTCo
   });
 
   it('should be able to update collection metadata', async () => {
-    const collectionMetadataInput = {
+    const collectionMetadataInput: CollectionMetadata = {
       name: 'Bar NFT Collection',
       description: 'This is the Bar NFT collection.',
-      externalUrl: 'https://bar.com',
+      url: 'https://bar.com',
       squareImage: {
         url: 'https://bar.com/square.png',
         type: 'image/png',

--- a/packages/freshmint/config/index.ts
+++ b/packages/freshmint/config/index.ts
@@ -9,12 +9,24 @@ const defaultDataPathEdition = 'editions.csv';
 const defaultAssetPath = 'assets';
 
 export type FreshmintConfig = {
-  name: string;
-  description: string;
+  collection: CollectionConfig;
   contract: ContractConfig;
   ipfsPinningService: IPFSPinningServiceConfig;
   nftDataPath: string;
   nftAssetPath: string;
+};
+
+export type CollectionConfig = {
+  name: string;
+  description: string;
+  url: string;
+  images: CollectionImagesConfig;
+  socials: { [name: string]: string };
+};
+
+export type CollectionImagesConfig = {
+  square: string;
+  banner: string;
 };
 
 export type ContractConfig = {
@@ -51,8 +63,7 @@ export function loadConfig(modifySchema?: (schema: FreshmintConfigSchema) => voi
 }
 
 export function saveConfig(
-  name: string,
-  description: string,
+  collection: CollectionConfig,
   contract: ContractConfig,
   ipfsPinningServiceEndpoint: string,
   ipfsPinningServiceKey: string,
@@ -60,8 +71,7 @@ export function saveConfig(
 ) {
   new config.ConfigWriter<FreshmintConfigSchema>(freshmintConfigSchema)
     .setValues((schema) => {
-      schema.name.setValue(name);
-      schema.description.setValue(description);
+      schema.collection.setValue(collection);
 
       schema.contract.setValue(contract);
 
@@ -83,8 +93,16 @@ export function getDefaultDataPath(contractType: ContractType): string {
 }
 
 function getConfigSchema() {
-  const name = config.Field<string>('name');
-  const description = config.Field<string>('description');
+  const collection = config.Map<CollectionConfig>('collection', {
+    name: config.Field<string>('name'),
+    description: config.Field<string>('description'),
+    url: config.Field<string>('url'),
+    images: config.Map<CollectionImagesConfig>('images', {
+      square: config.Field<string>('square'),
+      banner: config.Field<string>('banner'),
+    }),
+    socials: config.Field<{ [name: string]: string }>('socials'),
+  });
 
   const contract = config.Map<ContractConfig>('contract', {
     name: config.Field<string>('name'),
@@ -113,8 +131,7 @@ function getConfigSchema() {
   });
 
   return {
-    name,
-    description,
+    collection,
     contract,
     ipfsPinningService,
     nftDataPath,

--- a/packages/freshmint/flow/index.ts
+++ b/packages/freshmint/flow/index.ts
@@ -1,4 +1,4 @@
-import { CollectionMetadata } from '@freshmint/core';
+import { CollectionMetadata, getHTTPURL, getIPFSCID, getIPFSPath } from '@freshmint/core';
 import { objectToDictionaryEntries } from '@freshmint/core/cadence';
 
 // @ts-ignore
@@ -128,11 +128,15 @@ export default class FlowGateway {
       [
         { type: t.String, value: collection.name },
         { type: t.String, value: collection.description },
-        { type: t.String, value: collection.externalUrl },
-        { type: t.String, value: collection.squareImage.source },
-        { type: t.String, value: collection.squareImage.mediaType },
-        { type: t.String, value: collection.bannerImage.source },
-        { type: t.String, value: collection.bannerImage.mediaType },
+        { type: t.String, value: collection.url },
+        { type: t.Optional(t.String), value: getIPFSCID(collection.squareImage) },
+        { type: t.Optional(t.String), value: getIPFSPath(collection.squareImage) },
+        { type: t.Optional(t.String), value: getHTTPURL(collection.squareImage) },
+        { type: t.String, value: collection.squareImage.type },
+        { type: t.Optional(t.String), value: getIPFSCID(collection.bannerImage) },
+        { type: t.Optional(t.String), value: getIPFSPath(collection.bannerImage) },
+        { type: t.Optional(t.String), value: getHTTPURL(collection.bannerImage) },
+        { type: t.String, value: collection.bannerImage.type },
         {
           type: t.Dictionary({ key: t.String, value: t.String }),
           value: objectToDictionaryEntries(collection.socials),

--- a/packages/freshmint/flow/index.ts
+++ b/packages/freshmint/flow/index.ts
@@ -134,16 +134,20 @@ export default class FlowGateway {
   }
 
   async setCollectionMetadata(collection: CollectionMetadataInput) {
-    return await this.flow.transaction('./cadence/transactions/set_collection_metadata.cdc', `${this.network}-account`, [
-      { type: t.String, value: collection.name },
-      { type: t.String, value: collection.description },
-      { type: t.String, value: collection.externalUrl },
-      { type: t.String, value: collection.squareImage.source },
-      { type: t.String, value: collection.squareImage.mediaType },
-      { type: t.String, value: collection.bannerImage.source },
-      { type: t.String, value: collection.bannerImage.mediaType },
-      { type: t.Dictionary({ key: t.String, value: t.String }), value: objectToDictionary(collection.socials) },
-    ]);
+    return await this.flow.transaction(
+      './cadence/transactions/set_collection_metadata.cdc',
+      `${this.network}-account`,
+      [
+        { type: t.String, value: collection.name },
+        { type: t.String, value: collection.description },
+        { type: t.String, value: collection.externalUrl },
+        { type: t.String, value: collection.squareImage.source },
+        { type: t.String, value: collection.squareImage.mediaType },
+        { type: t.String, value: collection.bannerImage.source },
+        { type: t.String, value: collection.bannerImage.mediaType },
+        { type: t.Dictionary({ key: t.String, value: t.String }), value: objectToDictionary(collection.socials) },
+      ],
+    );
   }
 }
 

--- a/packages/freshmint/flow/index.ts
+++ b/packages/freshmint/flow/index.ts
@@ -1,22 +1,10 @@
+import { CollectionMetadata } from '@freshmint/core';
+import { objectToDictionaryEntries } from '@freshmint/core/cadence';
+
 // @ts-ignore
 import * as t from '@onflow/types';
 
 import FlowCliWrapper from './cli';
-
-export interface CollectionMetadataInput {
-  name: string;
-  description: string;
-  externalUrl: string;
-  squareImage: {
-    source: string;
-    mediaType: string;
-  };
-  bannerImage: {
-    source: string;
-    mediaType: string;
-  };
-  socials: { [name: string]: string };
-}
 
 // Use the maximum compute limit for minting transactions.
 //
@@ -133,7 +121,7 @@ export default class FlowGateway {
     ]);
   }
 
-  async setCollectionMetadata(collection: CollectionMetadataInput) {
+  async setCollectionMetadata(collection: CollectionMetadata) {
     return await this.flow.transaction(
       './cadence/transactions/set_collection_metadata.cdc',
       `${this.network}-account`,
@@ -145,12 +133,11 @@ export default class FlowGateway {
         { type: t.String, value: collection.squareImage.mediaType },
         { type: t.String, value: collection.bannerImage.source },
         { type: t.String, value: collection.bannerImage.mediaType },
-        { type: t.Dictionary({ key: t.String, value: t.String }), value: objectToDictionary(collection.socials) },
+        {
+          type: t.Dictionary({ key: t.String, value: t.String }),
+          value: objectToDictionaryEntries(collection.socials),
+        },
       ],
     );
   }
-}
-
-function objectToDictionary(obj: { [key: string]: any }): { key: string; value: any }[] {
-  return Object.entries(obj).map(([key, value]) => ({ key, value }));
 }

--- a/packages/freshmint/flow/index.ts
+++ b/packages/freshmint/flow/index.ts
@@ -3,6 +3,21 @@ import * as t from '@onflow/types';
 
 import FlowCliWrapper from './cli';
 
+export interface CollectionDisplayInput {
+  name: string;
+  description: string;
+  externalUrl: string;
+  squareImage: {
+    source: string;
+    mediaType: string;
+  };
+  bannerImage: {
+    source: string;
+    mediaType: string;
+  };
+  socials: { [name: string]: string };
+}
+
 // Use the maximum compute limit for minting transactions.
 //
 // This allows users to set the highest possible batch size.
@@ -117,4 +132,21 @@ export default class FlowGateway {
       { type: t.String, value: saleId },
     ]);
   }
+
+  async setCollectionDisplay(collection: CollectionDisplayInput) {
+    return await this.flow.transaction('./cadence/transactions/set_collection_display.cdc', `${this.network}-account`, [
+      { type: t.String, value: collection.name },
+      { type: t.String, value: collection.description },
+      { type: t.String, value: collection.externalUrl },
+      { type: t.String, value: collection.squareImage.source },
+      { type: t.String, value: collection.squareImage.mediaType },
+      { type: t.String, value: collection.bannerImage.source },
+      { type: t.String, value: collection.bannerImage.mediaType },
+      { type: t.Dictionary({ key: t.String, value: t.String }), value: objectToDictionary(collection.socials) },
+    ]);
+  }
+}
+
+function objectToDictionary(obj: { [key: string]: any }): { key: string; value: any }[] {
+  return Object.entries(obj).map(([key, value]) => ({ key, value }));
 }

--- a/packages/freshmint/flow/index.ts
+++ b/packages/freshmint/flow/index.ts
@@ -3,7 +3,7 @@ import * as t from '@onflow/types';
 
 import FlowCliWrapper from './cli';
 
-export interface CollectionDisplayInput {
+export interface CollectionMetadataInput {
   name: string;
   description: string;
   externalUrl: string;
@@ -133,8 +133,8 @@ export default class FlowGateway {
     ]);
   }
 
-  async setCollectionDisplay(collection: CollectionDisplayInput) {
-    return await this.flow.transaction('./cadence/transactions/set_collection_display.cdc', `${this.network}-account`, [
+  async setCollectionMetadata(collection: CollectionMetadataInput) {
+    return await this.flow.transaction('./cadence/transactions/set_collection_metadata.cdc', `${this.network}-account`, [
       { type: t.String, value: collection.name },
       { type: t.String, value: collection.description },
       { type: t.String, value: collection.externalUrl },

--- a/packages/freshmint/fresh.ts
+++ b/packages/freshmint/fresh.ts
@@ -114,4 +114,27 @@ export default class Fresh {
   async stopDrop() {
     await this.flowGateway.stopDrop('default');
   }
+
+  async updateCollection() {
+    const collection = this.config.collection;
+
+    const collectonInput = {
+      name: collection.name,
+      description: collection.description,
+      externalUrl: collection.url,
+      squareImage: {
+        source: collection.images.square,
+        // TODO: remove hard-coded media type
+        mediaType: 'image/png',
+      },
+      bannerImage: {
+        source: collection.images.banner,
+        // TODO: remove hard-coded media type
+        mediaType: 'image/png',
+      },
+      socials: collection.socials,
+    };
+
+    await this.flowGateway.setCollectionDisplay(collectonInput);
+  }
 }

--- a/packages/freshmint/fresh.ts
+++ b/packages/freshmint/fresh.ts
@@ -2,6 +2,9 @@ import { createObjectCsvWriter as createCsvWriter } from 'csv-writer';
 import { NFTStorage } from 'nft.storage';
 import * as metadata from '@freshmint/core/metadata';
 
+// @ts-ignore
+import mime from 'mime-types';
+
 import { FreshmintConfig } from './config';
 import FlowGateway from './flow';
 import IPFS from './ipfs';
@@ -124,13 +127,11 @@ export default class Fresh {
       externalUrl: collection.url,
       squareImage: {
         source: collection.images.square,
-        // TODO: remove hard-coded media type
-        mediaType: 'image/png',
+        mediaType: mime.lookup(collection.images.square) || '',
       },
       bannerImage: {
         source: collection.images.banner,
-        // TODO: remove hard-coded media type
-        mediaType: 'image/png',
+        mediaType: mime.lookup(collection.images.banner) || '',
       },
       socials: collection.socials,
     };

--- a/packages/freshmint/fresh.ts
+++ b/packages/freshmint/fresh.ts
@@ -136,6 +136,8 @@ export default class Fresh {
       socials: collection.socials,
     };
 
-    await this.flowGateway.setCollectionDisplay(collectonInput);
+    await this.flowGateway.setCollectionMetadata(collectonInput);
+
+    return collectonInput;
   }
 }

--- a/packages/freshmint/fresh.ts
+++ b/packages/freshmint/fresh.ts
@@ -1,5 +1,6 @@
 import { createObjectCsvWriter as createCsvWriter } from 'csv-writer';
 import { NFTStorage } from 'nft.storage';
+import { CollectionMetadata } from '@freshmint/core';
 import * as metadata from '@freshmint/core/metadata';
 
 // @ts-ignore
@@ -121,23 +122,23 @@ export default class Fresh {
   async updateCollection() {
     const collection = this.config.collection;
 
-    const collectonInput = {
+    const collectonMetadata: CollectionMetadata = {
       name: collection.name,
       description: collection.description,
-      externalUrl: collection.url,
+      url: collection.url,
       squareImage: {
-        source: collection.images.square,
-        mediaType: mime.lookup(collection.images.square) || '',
+        url: collection.images.square,
+        type: mime.lookup(collection.images.square) || '',
       },
       bannerImage: {
-        source: collection.images.banner,
-        mediaType: mime.lookup(collection.images.banner) || '',
+        url: collection.images.banner,
+        type: mime.lookup(collection.images.banner) || '',
       },
       socials: collection.socials,
     };
 
-    await this.flowGateway.setCollectionMetadata(collectonInput);
+    await this.flowGateway.setCollectionMetadata(collectonMetadata);
 
-    return collectonInput;
+    return collectonMetadata;
   }
 }

--- a/packages/freshmint/generateProject.ts
+++ b/packages/freshmint/generateProject.ts
@@ -116,6 +116,11 @@ async function generateStandardProject(
     path.resolve(dir, `cadence/scripts/get_nfts.cdc`),
     CommonNFTGenerator.getNFTs({ imports: shiftedImports, contractName: contract.name, contractAddress }),
   );
+
+  await writeFile(
+    path.resolve(dir, `cadence/transactions/set_collection_metadata.cdc`),
+    CommonNFTGenerator.setCollectionMetadata({ imports: shiftedImports, contractName: contract.name, contractAddress }),
+  );
 }
 
 async function generateEditionProject(
@@ -172,6 +177,11 @@ async function generateEditionProject(
   await writeFile(
     path.resolve(dir, `cadence/scripts/get_nfts.cdc`),
     CommonNFTGenerator.getNFTs({ imports: shiftedImports, contractName: contract.name, contractAddress }),
+  );
+
+  await writeFile(
+    path.resolve(dir, `cadence/transactions/set_collection_metadata.cdc`),
+    CommonNFTGenerator.setCollectionMetadata({ imports: shiftedImports, contractName: contract.name, contractAddress }),
   );
 }
 

--- a/packages/freshmint/index.ts
+++ b/packages/freshmint/index.ts
@@ -188,7 +188,7 @@ async function mint({
 
   let bar: ProgressBar;
 
-  spinner.start(`Checking for duplicate NFTs ...\n`);
+  spinner.start('Checking for duplicate NFTs ...\n');
 
   await minter.mint(
     loader,
@@ -253,7 +253,7 @@ async function stopDrop({ network }: { network: string }) {
 
   // TODO: return error if no drop is active
 
-  spinner.succeed(`Your drop has been stopped.`);
+  spinner.succeed('Your drop has been stopped.');
 }
 
 function getNFTOutput(nft: models.NFT, contractConfig: ContractConfig) {
@@ -289,10 +289,14 @@ async function updateCollection({ network }: { network: string }) {
   const config = loadConfig();
   const fresh = new Fresh(config, network);
 
-  await fresh.updateCollection();
+  spinner.start('Updating collection metadata ...\n');
 
-  // TODO: print collection data here
-  spinner.succeed(`Your contract has been updated with new collection metadata.`);
+  const collectionMetadata = await fresh.updateCollection();
+
+  spinner.succeed('Updated your contract with new collection metadata:');
+
+  // TODO: pretty print instead of dumping the object
+  console.log(collectionMetadata)
 }
 
 async function generateCadence() {

--- a/packages/freshmint/index.ts
+++ b/packages/freshmint/index.ts
@@ -111,6 +111,12 @@ async function main() {
     .option('-n, --network <network>', "Network to use. Either 'emulator', 'testnet' or 'mainnet'", 'emulator')
     .option('--tail <number>', 'Only dump the last <number> NFTs. ', parseIntOption)
     .action(dumpNFTs);
+  
+  program
+    .command('update-collection')
+    .description('update the collection metadata on your contract')
+    .option('-n, --network <network>', "Network to use. Either 'emulator', 'testnet' or 'mainnet'", 'emulator')
+    .action(updateCollection);
 
   const generate = program.command('generate').description('regenerate project files from config');
 
@@ -279,6 +285,16 @@ async function dumpNFTs(csvPath: string, { network, tail }: { network: string; t
   spinner.succeed(`${count} NFT records saved to ${csvPath}.`);
 }
 
+async function updateCollection({ network }: { network: string }) {
+  const config = loadConfig();
+  const fresh = new Fresh(config, network);
+
+  await fresh.updateCollection();
+
+  // TODO: print collection data here
+  spinner.succeed(`Your contract has been updated with new collection metadata.`);
+}
+
 async function generateCadence() {
   const config = loadConfig();
 
@@ -290,7 +306,7 @@ async function generateCadence() {
 async function generateWeb() {
   const config = loadConfig();
 
-  await generateNextjsApp('./', config.name, config.description);
+  await generateNextjsApp('./', config.collection.name, config.collection.description);
 
   spinner.succeed(`Success! Regenerated web files.`);
 }

--- a/packages/freshmint/index.ts
+++ b/packages/freshmint/index.ts
@@ -111,7 +111,7 @@ async function main() {
     .option('-n, --network <network>', "Network to use. Either 'emulator', 'testnet' or 'mainnet'", 'emulator')
     .option('--tail <number>', 'Only dump the last <number> NFTs. ', parseIntOption)
     .action(dumpNFTs);
-  
+
   program
     .command('update-collection')
     .description('update the collection metadata on your contract')
@@ -296,7 +296,7 @@ async function updateCollection({ network }: { network: string }) {
   spinner.succeed('Updated your contract with new collection metadata:');
 
   // TODO: pretty print instead of dumping the object
-  console.log(collectionMetadata)
+  console.log(collectionMetadata);
 }
 
 async function generateCadence() {

--- a/packages/freshmint/package.json
+++ b/packages/freshmint/package.json
@@ -39,6 +39,7 @@
     "inquirer": "^8.2.2",
     "js-yaml": "^4.1.0",
     "nft.storage": "^3.3.0",
+    "mime-types": "^2.1.35",
     "node-fetch": "^2.6.7",
     "ora": "^5.4.1",
     "pouchdb": "^7.2.2",

--- a/packages/freshmint/start.ts
+++ b/packages/freshmint/start.ts
@@ -5,7 +5,7 @@ import { Ora } from 'ora';
 import inquirer from 'inquirer';
 import * as metadata from '@freshmint/core/metadata';
 
-import { saveConfig, ContractConfig, ContractType, getDefaultDataPath } from './config';
+import { saveConfig, ContractConfig, ContractType, getDefaultDataPath, CollectionConfig } from './config';
 import { generateProject } from './generateProject';
 
 const fieldChoices = metadata.fieldTypes
@@ -136,6 +136,19 @@ export default async function start(spinner: Ora, projectPath: string) {
 
   const answers = await inquirer.prompt(questions);
 
+  const collection: CollectionConfig = {
+    name: answers.name,
+    description: answers.description,
+    url: 'https://your-project.com',
+    images: {
+      square: 'square.png',
+      banner: 'banner.png',
+    },
+    socials: {
+      twitter: 'http://twitter.com/your-project',
+    },
+  };
+
   const userFields = await getCustomFields(answers.startCustomFields);
 
   const userSchema = metadata.parseSchema(userFields);
@@ -160,14 +173,7 @@ export default async function start(spinner: Ora, projectPath: string) {
     userSchema.fields,
   );
 
-  saveConfig(
-    answers.name,
-    answers.description,
-    contract,
-    '${PINNING_SERVICE_ENDPOINT}',
-    '${PINNING_SERVICE_KEY}',
-    projectPath,
-  );
+  saveConfig(collection, contract, '${PINNING_SERVICE_ENDPOINT}', '${PINNING_SERVICE_KEY}', projectPath);
 
   spinner.succeed(
     `✨ Project initialized in ${chalk.white(`${isCurrentDirectory ? 'the current directory.' : projectPath}\n`)}`,


### PR DESCRIPTION
This PR updates the NFT contract templates to include a `collectionMetadata` field that can be set and updated by the contract owner.

This allows developers to easily implement the `NFTCollectionDisplay` view and gives them the flexible to change their collection information as their project evolves (e.g. adding new social accounts, updating images, etc).

This work is related to https://github.com/packagelabs/freshmint/issues/117