### PR TITLE
Add transaction to transfer NFTs from a queue to a collection

### DIFF
--- a/cadence/nfts/common/transactions/setup_collection.template.cdc
+++ b/cadence/nfts/common/transactions/setup_collection.template.cdc
@@ -1,0 +1,25 @@
+import {{ contractName }} from {{{ contractAddress }}}
+
+import NonFungibleToken from {{{ imports.NonFungibleToken }}}
+import MetadataViews from {{{ imports.MetadataViews }}}
+
+transaction {
+    prepare(signer: AuthAccount) {
+        // Return early if the account already has a collection
+        if signer.borrow<&{{ contractName }}.Collection>(from: {{ contractName }}.CollectionStoragePath) != nil {
+            return
+        }
+
+        // Create a new empty collection
+        let collection <- {{ contractName }}.createEmptyCollection()
+
+        // Save the collection to the account
+        signer.save(<-collection, to: {{ contractName }}.CollectionStoragePath)
+
+        // Link a public capability for the collection
+        signer.link<&{{ contractName }}.Collection{NonFungibleToken.CollectionPublic, {{ contractName }}.{{ contractName }}CollectionPublic, MetadataViews.ResolverCollection}>(
+            {{ contractName }}.CollectionPublicPath,
+            target: {{ contractName }}.CollectionStoragePath
+        )
+    }
+}

--- a/cadence/nfts/common/transactions/transfer_queue_to_collection.template.cdc
+++ b/cadence/nfts/common/transactions/transfer_queue_to_collection.template.cdc
@@ -1,0 +1,51 @@
+import {{ contractName }} from {{{ contractAddress }}}
+
+import NonFungibleToken from {{{ imports.NonFungibleToken }}}
+import MetadataViews from {{{ imports.MetadataViews }}}
+import FreshmintQueue from {{{ imports.FreshmintQueue }}}
+
+/// This transaction moves NFTs from a queue to collection.
+///
+/// Parameters:
+/// - fromBucketName: the bucket name to withdraw from. If nil, the default bucket is used.
+/// - recipientAddress: the address of the account to deposit to.
+/// - count: the number of NFTs to move.
+///
+transaction(
+    fromBucketName: String?,
+    recipientAddress: Address,
+    count: Int
+) {
+
+    let fromQueue: &FreshmintQueue.CollectionQueue
+    let toCollection: &{NonFungibleToken.CollectionPublic}
+
+    prepare(signer: AuthAccount) {
+
+        // Withdraw NFTs from the main mint queue
+        let fromQueueName = {{ contractName }}.makeQueueName(bucketName: fromBucketName)
+        let fromQueuePrivatePath = {{ contractName }}.getPrivatePath(suffix: fromQueueName)
+
+        self.fromQueue = signer
+            .getCapability<&FreshmintQueue.CollectionQueue>(fromQueuePrivatePath)
+            .borrow()!
+
+        self.toCollection = getAccount(recipientAddress)
+            .getCapability({{ contractName }}.CollectionPublicPath)
+            .borrow<&{NonFungibleToken.CollectionPublic}>()
+            ?? panic("failed to borrow a reference to the recipient's collection")
+    }
+
+    execute {
+        var i = 0
+
+        // Withdraw the first `count` NFTs from the queue and deposit them into the collection
+        while i < count {
+            let token <- self.fromQueue.getNextNFT()!
+
+            self.toCollection.deposit(token: <- token)
+
+            i = i + 1
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12691,7 +12691,7 @@
     },
     "packages/core": {
       "name": "@freshmint/core",
-      "version": "0.2.2-alpha",
+      "version": "0.2.2-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@onflow/fcl": "^1.2.0",

--- a/packages/core/contracts/FreshmintClaimSaleV2Contract.test.ts
+++ b/packages/core/contracts/FreshmintClaimSaleV2Contract.test.ts
@@ -17,9 +17,6 @@ import {
   TestAccount,
 } from '../testHelpers';
 
-// Increase test timeout for longer emulator tests
-jest.setTimeout(10000);
-
 describe('FreshmintClaimSaleV2Contract', () => {
   beforeAll(setupEmulator);
   afterAll(teardownEmulator);

--- a/packages/core/contracts/NFTContract.ts
+++ b/packages/core/contracts/NFTContract.ts
@@ -6,7 +6,7 @@ import * as t from '@onflow/types';
 
 import * as metadata from '../metadata';
 import { FreshmintConfig } from '../config';
-import { Transaction, TransactionAuthorizer, TransactionSigners } from '../transactions';
+import { Transaction, TransactionAuthorizer, TransactionResult, TransactionSigners } from '../transactions';
 import { Script } from '../scripts';
 import { Path } from '../cadence/values';
 import { CommonNFTGenerator } from '../generators/CommonNFTGenerator';
@@ -140,6 +140,27 @@ export abstract class NFTContract {
     }, Transaction.VoidResult);
   }
 
+  setupCollection(authorizer: TransactionAuthorizer): Transaction<void> {
+    return new Transaction(({ imports }: FreshmintConfig) => {
+      const script = CommonNFTGenerator.setupCollection({
+        imports,
+        contractName: this.name,
+        contractAddress: this.getAddress(),
+      });
+
+      return {
+        script,
+        args: [],
+        computeLimit: 9999,
+        signers: {
+          payer: authorizer,
+          proposer: authorizer,
+          authorizers: [authorizer],
+        },
+      };
+    }, Transaction.VoidResult);
+  }
+
   transferQueueToQueue({
     fromQueue,
     toQueue,
@@ -167,6 +188,41 @@ export abstract class NFTContract {
         signers: this.getSigners(),
       };
     }, Transaction.VoidResult);
+  }
+
+  transferQueueToCollection({
+    fromQueue,
+    toAddress,
+    count,
+  }: {
+    fromQueue: string | null;
+    toAddress: string;
+    count: number;
+  }): Transaction<string[]> {
+    return new Transaction(
+      ({ imports }: FreshmintConfig) => {
+        const script = CommonNFTGenerator.transferQueueToCollection({
+          imports,
+          contractName: this.name,
+          contractAddress: this.getAddress(),
+        });
+
+        return {
+          script,
+          args: [
+            fcl.arg(fromQueue, t.Optional(t.String)),
+            fcl.arg(toAddress, t.Address),
+            fcl.arg(count.toString(), t.Int),
+          ],
+          computeLimit: 9999,
+          signers: this.getSigners(),
+        };
+      },
+      ({ events }: TransactionResult) => {
+        const deposits = events.filter((event) => event.type.includes('.Deposit'));
+        return deposits.map((event) => event.data.id);
+      },
+    );
   }
 
   getCollectionMetadata(): Script<CollectionMetadata | null> {

--- a/packages/core/contracts/StandardNFTContract.test.ts
+++ b/packages/core/contracts/StandardNFTContract.test.ts
@@ -12,6 +12,7 @@ import {
   setupEmulator,
   teardownEmulator,
   collectionMetadata,
+  createAccount,
 } from '../testHelpers';
 
 describe('StandardNFTContract', () => {

--- a/packages/core/contracts/transfer.test.ts
+++ b/packages/core/contracts/transfer.test.ts
@@ -1,0 +1,53 @@
+import { StandardNFTContract } from './StandardNFTContract';
+
+import {
+  client,
+  collectionMetadata,
+  contractHashAlgorithm,
+  contractPublicKey,
+  createAccount,
+  getTestNFTs,
+  getTestSchema,
+  ownerAuthorizer,
+  setupEmulator,
+  teardownEmulator,
+} from '../testHelpers';
+
+describe('Transfer NFTs', () => {
+  const contract = new StandardNFTContract({
+    name: 'StandardNFT_Transfer_Test',
+    schema: getTestSchema(),
+    owner: ownerAuthorizer,
+  });
+
+  beforeAll(async () => {
+    await setupEmulator();
+
+    await client.send(
+      contract.deploy({
+        publicKey: contractPublicKey,
+        hashAlgorithm: contractHashAlgorithm,
+        collectionMetadata,
+      }),
+    );
+  });
+
+  afterAll(teardownEmulator);
+
+  it('should transfer NFTs from the default queue to another account', async () => {
+    // Create a new account and set up an NFT collection
+    const account = await createAccount();
+    await client.send(contract.setupCollection(account.authorizer));
+
+    // Mint 5 new NFTs
+    const mintedNFTs = await client.send(contract.mintNFTs(getTestNFTs(5)));
+    const mintedIDs = mintedNFTs.map((nft) => nft.id);
+
+    const transferredIDs = await client.send(
+      contract.transferQueueToCollection({ fromQueue: null, toAddress: account.address, count: 5 }),
+    );
+
+    // Transferred IDs should match the minted IDs
+    expect(transferredIDs).toEqual(mintedIDs);
+  });
+});

--- a/packages/core/generators/CommonNFTGenerator.ts
+++ b/packages/core/generators/CommonNFTGenerator.ts
@@ -62,6 +62,22 @@ export class CommonNFTGenerator extends TemplateGenerator {
     });
   }
 
+  static setupCollection({
+    imports,
+    contractName,
+    contractAddress,
+  }: {
+    imports: ContractImports;
+    contractName: string;
+    contractAddress: string;
+  }): string {
+    return this.generate(require('../../../cadence/nfts/common/transactions/setup_collection.template.cdc'), {
+      imports,
+      contractName,
+      contractAddress,
+    });
+  }
+
   static transferQueueToQueue({
     imports,
     contractName,
@@ -76,6 +92,25 @@ export class CommonNFTGenerator extends TemplateGenerator {
       contractName,
       contractAddress,
     });
+  }
+
+  static transferQueueToCollection({
+    imports,
+    contractName,
+    contractAddress,
+  }: {
+    imports: ContractImports;
+    contractName: string;
+    contractAddress: string;
+  }): string {
+    return this.generate(
+      require('../../../cadence/nfts/common/transactions/transfer_queue_to_collection.template.cdc'),
+      {
+        imports,
+        contractName,
+        contractAddress,
+      },
+    );
   }
 
   static getRoyalties({

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freshmint/core",
-  "version": "0.2.2-alpha",
+  "version": "0.2.2-alpha.1",
   "description": "The core templates and logic that power Freshmint.",
   "contributors": [
     "Mackenzie Kieran",

--- a/packages/core/testHelpers.ts
+++ b/packages/core/testHelpers.ts
@@ -35,6 +35,9 @@ const config = EMULATOR;
 
 export const client = FreshmintClient.fromFCL(fcl, config);
 
+// Increase test timeout for longer emulator tests
+jest.setTimeout(10000);
+
 export async function setupEmulator() {
   fcl.config().put('accessNode.api', `http://localhost:${emulatorPort}`);
 


### PR DESCRIPTION
This PR adds a transaction that transfers NFTs from a `CollectionQueue` in the signer's account to a `Collection` and the recipient account.

For example, this transaction can be used to move NFTs out of the main mint queue and into another account.