### PR TITLE
Add NFT metadata to `Burned` event in standard NFT template

### DIFF
--- a/cadence/nfts/standard-nft/StandardNFT.template.cdc
+++ b/cadence/nfts/standard-nft/StandardNFT.template.cdc
@@ -11,7 +11,7 @@ pub contract {{ contractName }}: NonFungibleToken {
     pub event Withdraw(id: UInt64, from: Address?)
     pub event Deposit(id: UInt64, to: Address?)
     pub event Minted(id: UInt64)
-    pub event Burned(id: UInt64)
+    pub event Burned(id: UInt64, metadata: Metadata)
 
     pub let CollectionStoragePath: StoragePath
     pub let CollectionPublicPath: PublicPath
@@ -89,7 +89,10 @@ pub contract {{ contractName }}: NonFungibleToken {
         destroy() {
             {{ contractName }}.totalSupply = {{ contractName }}.totalSupply - (1 as UInt64)
 
-            emit Burned(id: self.id)
+            // This contract includes metadata in the burn event so that off-chain systems
+            // can retroactively index NFTs that were burned in past sporks.
+            //
+            emit Burned(id: self.id, metadata: self.metadata)
         }
     }
 

--- a/packages/core/contracts/StandardNFTContract.test.ts
+++ b/packages/core/contracts/StandardNFTContract.test.ts
@@ -1,4 +1,4 @@
-import { StandardNFTContract } from './StandardNFTContract';
+import { NFTMintResult, StandardNFTContract } from './StandardNFTContract';
 import { MissingContractAddressError } from './NFTContract';
 import { FreshmintClaimSaleContract } from './FreshmintClaimSaleContract';
 
@@ -28,7 +28,7 @@ describe('StandardNFTContract', () => {
     expect(contract.getSource(client.config.imports)).toMatchSnapshot();
   });
 
-  const nfts = new NFTGenerator().generate(3);
+  const nfts = new NFTGenerator().generate(4);
 
   it('should fail to mint NFTs before contract is deployed', async () => {
     await expect(async () => await client.send(contract.mintNFTs(nfts))).rejects.toThrow(MissingContractAddressError);
@@ -62,14 +62,21 @@ describe('StandardNFTContract', () => {
     );
   });
 
+  let mintedNFTs: NFTMintResult[] = [];
+
   it('should mint NFTs', async () => {
-    await client.send(contract.mintNFTs(nfts));
+    mintedNFTs = await client.send(contract.mintNFTs(nfts));
   });
 
   it('should fail to mint duplicate NFTs', async () => {
     await expect(async () => {
       await client.send(contract.mintNFTs(nfts));
     }).rejects.toThrow();
+  });
+
+  it('should burn an NFT', async () => {
+    const nft = mintedNFTs[0];
+    await client.send(contract.destroyNFT(nft.id));
   });
 
   const sale = new FreshmintClaimSaleContract(contract);

--- a/packages/core/contracts/__snapshots__/StandardNFTContract.test.ts.snap
+++ b/packages/core/contracts/__snapshots__/StandardNFTContract.test.ts.snap
@@ -14,7 +14,7 @@ pub contract StandardNFT_Test: NonFungibleToken {
     pub event Withdraw(id: UInt64, from: Address?)
     pub event Deposit(id: UInt64, to: Address?)
     pub event Minted(id: UInt64)
-    pub event Burned(id: UInt64)
+    pub event Burned(id: UInt64, metadata: Metadata)
 
     pub let CollectionStoragePath: StoragePath
     pub let CollectionPublicPath: PublicPath
@@ -169,7 +169,10 @@ pub contract StandardNFT_Test: NonFungibleToken {
         destroy() {
             StandardNFT_Test.totalSupply = StandardNFT_Test.totalSupply - (1 as UInt64)
 
-            emit Burned(id: self.id)
+            // This contract includes metadata in the burn event so that off-chain systems
+            // can retroactively index NFTs that were burned in past sporks.
+            //
+            emit Burned(id: self.id, metadata: self.metadata)
         }
     }
 


### PR DESCRIPTION
This PR updates the `Burned` event in the standard NFT contract to include the NFT's metadata. This allows indexers to retroactively index NFTs that were burned in a previous spork, given that Flow does not yet support script execution in past sporks.