### PR TITLE
Fix an error with node18

### DIFF
--- a/packages/core/crypto/elliptic.ts
+++ b/packages/core/crypto/elliptic.ts
@@ -1,4 +1,4 @@
-import * as elliptic from 'elliptic';
+import elliptic from 'elliptic';
 
 import { PublicKey } from './publicKey';
 import { Signer, SignatureAlgorithm } from './sign';


### PR DESCRIPTION
While working on the hackathon for flow I had the following error while importing the package /node_modules/@freshmint/core/crypto/elliptic.ts:7 2023-02-23 11:33:06 const ECDSA_P256 = new elliptic.ec('p256');

Changeing the way the package is imported resolved the issue which seems to be due to the fact that this package export his class as default already and using the * induce an error from the nodejs imports